### PR TITLE
Improve onboarding for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Installation and Usage
 
-The steps below will walk you through setting up RAM Docs
+The steps below will walk you through setting up RAM Docs. To install RAM itself, head over to the [ram-backend repository](https://github.com/WorldBank-Transport/ram-backend)!
 
 ### Install Project Dependencies
 To set up the development environment for this website, you'll need to install the following on your system:

--- a/app/posts/s0-introduction/0-1-introduction/0-1-0-index.md
+++ b/app/posts/s0-introduction/0-1-introduction/0-1-0-index.md
@@ -13,3 +13,5 @@ RAM is under active development. Its codebase is available on Github:
 - [RAM frontend](https://github.com/WorldBank-Transport/ram-frontend) with the code for the user interface
 - [RAM iD](https://github.com/WorldBank-Transport/ram-iD), a customized version of [iD](https://github.com/openstreetmap/iD) to allow editing of the road network
 - [RAM data pipeline](https://github.com/WorldBank-Transport/ram-datapipeline) that handles some of the more intensive data processing
+
+To get a local dev version of everything up and running quickly check out https://github.com/WorldBank-Transport/ram-backend#offline-usage


### PR DESCRIPTION
After landing on https://developmentseed.org/projects/ram/ I ran into a few user flow issues while trying to install RAM locally that I think could be easily fixed by this PR and 
1. Change the link for "grab the source code and run it here" on https://developmentseed.org/projects/ram/ since this docs repo doesn't really help you with the stated task directly. I would recommend linking directly to https://github.com/WorldBank-Transport/ram-backend#offline-usage
2. Change the description of https://github.com/worldbank-transport/ram to "Rural Accessibility Map Documentation" and add a link to http://ruralaccess.info/ for the website.